### PR TITLE
feat: add userquery view

### DIFF
--- a/django_backend/api_gateway/serializers.py
+++ b/django_backend/api_gateway/serializers.py
@@ -19,3 +19,8 @@ class MyTokenPairObtainSerializer(TokenObtainPairSerializer):
             token["tenant_id"] = None
         
         return token
+    
+
+
+class UserQuerySerializer(serializers.Serializer):
+    question = serializers.CharField(max_length = 1000)

--- a/django_backend/api_gateway/urls.py
+++ b/django_backend/api_gateway/urls.py
@@ -1,12 +1,13 @@
 from rest_framework_simplejwt.views import TokenRefreshView
-from .views import MyTokenObtainPairView
+from .views import MyTokenObtainPairView, UserQueryView
 from django.urls import path
 from .views import HelloWorldView
 
 urlpatterns = [
     path("api/token/", MyTokenObtainPairView.as_view(), name = "token_obtain_pair"),
     path("api/token/refresh", TokenRefreshView.as_view(), name = "token_refresh"),
-    path("api/hello", HelloWorldView.as_view(), name = "hello_view")
+    path("api/hello", HelloWorldView.as_view(), name = "hello_view"),
+    path("user/query", UserQueryView.as_view(),name = "user_query")
 
 
 ]

--- a/django_backend/api_gateway/views.py
+++ b/django_backend/api_gateway/views.py
@@ -1,10 +1,12 @@
 from rest_framework_simplejwt.views import TokenObtainPairView
-from .serializers import MyTokenPairObtainSerializer
+from .serializers import MyTokenPairObtainSerializer, UserQuerySerializer
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from .models import Tenant
 from .utils import TenantContextMixin
+from rest_framework.response import Response
+
 
 
 class MyTokenObtainPairView(TokenObtainPairView):
@@ -19,4 +21,20 @@ class HelloWorldView(TenantContextMixin,APIView):
         return Response({
             "message": f"Hello, {tenant.name}",
             "tenant_id": tenant.id
+        })
+    
+
+class UserQueryView(TenantContextMixin, APIView):
+    permission_classes = [IsAuthenticated]
+    def post(self, request):
+        serializer = UserQuerySerializer(data = request.data)
+        serializer.is_valid(raise_exception=True)
+        tenant = self.get_tenant(request)
+        question = serializer.validated_data['question']
+
+
+        return Response({
+            "tenant":tenant.name,
+            "question":question,
+            "answer":f"You asked: '{question} - I'll answer this soon.'"
         })


### PR DESCRIPTION
This PR introduces the User Query API endpoint for DialogBox:

- Accepts user question via POST
- Authenticated with JWT
- Uses `TenantContextMixin` to identify the tenant
- Returns a mock response for now (to be replaced with real retrieval/LLM)

## ✅ Completed Tasks

- [x] Created `UserQuerySerializer`
- [x] Created `UserQueryView` with tenant context
- [x] Added `/api/user/query/` route
- [x] Tested with JWT authentication

## 🧪 Testing Steps

- Logged in and obtained JWT
- Called POST `/api/user/query/` with sample question
- Verified mock response includes tenant name and input question